### PR TITLE
Added Swiftype Site Search

### DIFF
--- a/themes/beautifulhugo/layouts/partials/search.html
+++ b/themes/beautifulhugo/layouts/partials/search.html
@@ -1,40 +1,28 @@
-<!-- HTML Markup -->
-<div class="aa-input-container" id="aa-input-container">
-    <input type="search" id="aa-search-input" class="aa-input-search" placeholder="Search for titles or URIs..." name="search" autocomplete="off" />
-    <svg class="aa-input-icon" viewBox="654 -372 1664 1664">
-        <path d="M1806,332c0-123.3-43.8-228.8-131.5-316.5C1586.8-72.2,1481.3-116,1358-116s-228.8,43.8-316.5,131.5  C953.8,103.2,910,208.7,910,332s43.8,228.8,131.5,316.5C1129.2,736.2,1234.7,780,1358,780s228.8-43.8,316.5-131.5  C1762.2,560.8,1806,455.3,1806,332z M2318,1164c0,34.7-12.7,64.7-38,90s-55.3,38-90,38c-36,0-66-12.7-90-38l-343-342  c-119.3,82.7-252.3,124-399,124c-95.3,0-186.5-18.5-273.5-55.5s-162-87-225-150s-113-138-150-225S654,427.3,654,332  s18.5-186.5,55.5-273.5s87-162,150-225s138-113,225-150S1262.7-372,1358-372s186.5,18.5,273.5,55.5s162,87,225,150s113,138,150,225  S2062,236.7,2062,332c0,146.7-41.3,279.7-124,399l343,343C2305.7,1098.7,2318,1128.7,2318,1164z" />
-    </svg>
+<style>
+  .st-default-search-input {
+    width: calc(100% - 45px);
+  }
+</style>
+<div>
+  <form>
+    <input type="text" class="st-default-search-input" />
+  </form>
 </div>
-<!-- Include AlgoliaSearch JS Client and autocomplete.js library -->
-<!-- CDN有时候访问不了
-<script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
-<script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
--->
-<!--
-<script src="{{ "js/algoliasearch.min.js" | absURL }}"></script>
-<script src="{{ "js/autocomplete.min.js" | absURL }}"></script>
--->
-<script src="{{ "https://res.cloudinary.com/martinliu/raw/upload/static/algoliasearch.min.js" | absURL }}"></script>
-<script src="{{ "https://res.cloudinary.com/martinliu/raw/upload/static/autocomplete.min.js" | absURL }}"></script>
-<!-- Initialize autocomplete menu -->
-<script>
-var client = algoliasearch("3RK9W7WH5R", "{{ .Site.Params.algolia }}");
-var index = client.initIndex('martinliu_blog');
-//initialize autocomplete on search input (ID selector must match)
-autocomplete('#aa-search-input',
-{ hint: false}, {
-    source: autocomplete.sources.hits(index, {hitsPerPage: 5}),
-    //value to be displayed in input control after user's suggestion selection
-    displayKey: 'name',
-    //hash of templates used when rendering dataset
-    templates: {
-        //'suggestion' templating function used to render a single suggestion
-        suggestion: function(suggestion) {
-            //TODO 需要去除链接中的<em>和</em>高亮的标签
-            return '<span>' + '<a href="/' + suggestion.uri+ '">' +
-            suggestion._highlightResult.title.value + '</a></span>';
-        }
-    }
-});
-</script>
 
+<script type="text/javascript">
+  (function(w, d, t, u, n, s, e) {
+    w["SwiftypeObject"] = n;
+    w[n] =
+      w[n] ||
+      function() {
+        (w[n].q = w[n].q || []).push(arguments);
+      };
+    s = d.createElement(t);
+    e = d.getElementsByTagName(t)[0];
+    s.async = 1;
+    s.src = u;
+    e.parentNode.insertBefore(s, e);
+  })(window, document, "script", "//s.swiftypecdn.com/install/v2/st.js", "_st");
+
+  _st("install", "aDZVsobynztkvByUQo5_", "2.0.0");
+</script>


### PR DESCRIPTION
Swiftype Site Search is likely the easiest way to add Swiftype search to your blog.

Instead of reading your Markdown files directly and indexing content via an API, Swiftype Site Search uses a web crawler to index your public website.

To create the engine being used in this test, I simply logged into Site Search, created a new Engine using your site URL https://martinliu.cn/, and then followed the instructions in the Dashboard for installing Site Search, which you see in this PR.

![latest](https://user-images.githubusercontent.com/1427475/53665559-c3f61e80-3c39-11e9-891e-b92fbfe143f9.gif)
